### PR TITLE
Improved custom model support on most NPCs

### DIFF
--- a/sp/src/game/server/hl2/npc_PoisonZombie.cpp
+++ b/sp/src/game/server/hl2/npc_PoisonZombie.cpp
@@ -256,7 +256,11 @@ END_DATADESC()
 //-----------------------------------------------------------------------------
 void CNPC_PoisonZombie::Precache( void )
 {
+#ifdef MAPBASE
+	PrecacheModel( DefaultOrCustomModel( "models/zombie/poison.mdl" ) );
+#else
 	PrecacheModel("models/zombie/poison.mdl");
+#endif
 
 	PrecacheScriptSound( "NPC_PoisonZombie.Die" );
 	PrecacheScriptSound( "NPC_PoisonZombie.ThrowWarn" );
@@ -509,7 +513,11 @@ void CNPC_PoisonZombie::SetZombieModel( void )
 	}
 	else
 	{
+#ifdef MAPBASE
+		SetModel( DefaultOrCustomModel( "models/zombie/poison.mdl" ) );
+#else
 		SetModel( "models/zombie/poison.mdl" );
+#endif
 		SetHullType(HULL_HUMAN);
 	}
 

--- a/sp/src/game/server/hl2/npc_antlion.cpp
+++ b/sp/src/game/server/hl2/npc_antlion.cpp
@@ -470,8 +470,13 @@ void CNPC_Antlion::Precache( void )
 #ifdef HL2_EPISODIC
 	if ( IsWorker() )
 	{
+#ifdef MAPBASE
+		PrecacheModel( DefaultOrCustomModel( ANTLION_WORKER_MODEL ) );
+		PropBreakablePrecacheAll( MAKE_STRING( DefaultOrCustomModel( ANTLION_WORKER_MODEL ) ) );
+#else
 		PrecacheModel( ANTLION_WORKER_MODEL );
 		PropBreakablePrecacheAll( MAKE_STRING( ANTLION_WORKER_MODEL ) );
+#endif
 		UTIL_PrecacheOther( "grenade_spit" );
 		PrecacheParticleSystem( "blood_impact_antlion_worker_01" );
 		PrecacheParticleSystem( "antlion_gib_02" );
@@ -480,8 +485,13 @@ void CNPC_Antlion::Precache( void )
 	else
 #endif // HL2_EPISODIC
 	{
+#ifdef MAPBASE
+		PrecacheModel( DefaultOrCustomModel(ANTLION_MODEL) );
+		PropBreakablePrecacheAll( MAKE_STRING( DefaultOrCustomModel( ANTLION_MODEL ) ) );
+#else
 		PrecacheModel( ANTLION_MODEL );
 		PropBreakablePrecacheAll( MAKE_STRING( ANTLION_MODEL ) );
+#endif
 		PrecacheParticleSystem( "blood_impact_antlion_01" );
 		PrecacheParticleSystem( "AntlionGib" );
 	}

--- a/sp/src/game/server/hl2/npc_combinecamera.cpp
+++ b/sp/src/game/server/hl2/npc_combinecamera.cpp
@@ -275,7 +275,11 @@ CNPC_CombineCamera::~CNPC_CombineCamera()
 //-----------------------------------------------------------------------------
 void CNPC_CombineCamera::Precache()
 {
+#ifdef MAPBASE
+	PrecacheModel( DefaultOrCustomModel( COMBINE_CAMERA_MODEL ) );
+#else
 	PrecacheModel(COMBINE_CAMERA_MODEL);
+#endif
 	PrecacheModel(COMBINE_CAMERA_GLOW_SPRITE);
 	PrecacheModel(COMBINE_CAMERA_FLASH_SPRITE);
 
@@ -304,8 +308,11 @@ void CNPC_CombineCamera::Precache()
 void CNPC_CombineCamera::Spawn()
 {
 	Precache();
-
+#ifdef MAPBASE
+	SetModel( DefaultOrCustomModel( COMBINE_CAMERA_MODEL ) );
+#else
 	SetModel(COMBINE_CAMERA_MODEL);
+#endif
 
 	m_pEyeFlash = CSprite::SpriteCreate(COMBINE_CAMERA_FLASH_SPRITE, GetLocalOrigin(), FALSE);
 	m_pEyeFlash->SetTransparency(kRenderGlow, 255, 255, 255, 0, kRenderFxNoDissipation);

--- a/sp/src/game/server/hl2/npc_combinedropship.cpp
+++ b/sp/src/game/server/hl2/npc_combinedropship.cpp
@@ -902,7 +902,11 @@ CNPC_CombineDropship::~CNPC_CombineDropship(void)
 void CNPC_CombineDropship::Spawn( void )
 {
 	Precache( );
+#ifdef MAPBASE
+	SetModel( DefaultOrCustomModel( "models/combine_dropship.mdl" ) );
+#else
 	SetModel( "models/combine_dropship.mdl" );
+#endif
 
 #ifdef _XBOX
 	AddEffects( EF_NOSHADOW );
@@ -1121,7 +1125,11 @@ void CNPC_CombineDropship::Activate( void )
 void CNPC_CombineDropship::Precache( void )
 {
 	// Models
+#ifdef MAPBASE
+	PrecacheModel( DefaultOrCustomModel( "models/combine_dropship.mdl" ) );
+#else
 	PrecacheModel("models/combine_dropship.mdl");
+#endif
 	switch ( m_iCrateType )
 	{
 	case CRATE_SOLDIER:

--- a/sp/src/game/server/hl2/npc_combinegunship.cpp
+++ b/sp/src/game/server/hl2/npc_combinegunship.cpp
@@ -547,11 +547,19 @@ void CNPC_CombineGunship::Spawn( void )
 
 	if ( HasSpawnFlags( SF_GUNSHIP_USE_CHOPPER_MODEL ) )
 	{
+#ifdef MAPBASE
+		SetModel( DefaultOrCustomModel( "models/combine_helicopter.mdl" ) );
+#else
 		SetModel( "models/combine_helicopter.mdl" );
+#endif
 	}
 	else
 	{
+#ifdef MAPBASE
+		SetModel( DefaultOrCustomModel( "models/gunship.mdl" ) );
+#else
 		SetModel( "models/gunship.mdl" );
+#endif
 	}
 	
 	ExtractBbox( SelectHeaviestSequence( ACT_GUNSHIP_PATROL ), m_cullBoxMins, m_cullBoxMaxs ); 
@@ -673,12 +681,20 @@ void CNPC_CombineGunship::Precache( void )
 {
 	if ( HasSpawnFlags( SF_GUNSHIP_USE_CHOPPER_MODEL ) )
 	{
+#ifdef MAPBASE
+		PrecacheModel( DefaultOrCustomModel( "models/combine_helicopter.mdl" ) );
+#else
 		PrecacheModel( "models/combine_helicopter.mdl" );
+#endif
 		Chopper_PrecacheChunks( this );
 	}
 	else
 	{
+#ifdef MAPBASE
+		PrecacheModel( DefaultOrCustomModel( "models/gunship.mdl" ) );
+#else
 		PrecacheModel("models/gunship.mdl");
+#endif
 	}
 
 	PrecacheModel("sprites/lgtning.vmt");
@@ -708,7 +724,11 @@ void CNPC_CombineGunship::Precache( void )
 		g_iGunshipEffectIndex = PrecacheModel( "sprites/physbeam.vmt" );
 	}
 
+#ifdef MAPBASE
+	PropBreakablePrecacheAll( MAKE_STRING( DefaultOrCustomModel( "models/gunship.mdl" ) ) );
+#else
 	PropBreakablePrecacheAll( MAKE_STRING("models/gunship.mdl") );
+#endif
 
 	BaseClass::Precache();
 }

--- a/sp/src/game/server/hl2/npc_dog.cpp
+++ b/sp/src/game/server/hl2/npc_dog.cpp
@@ -455,7 +455,11 @@ void CNPC_Dog::Spawn( void )
 
 	BaseClass::Spawn();
 
+#ifdef MAPBASE
+	SetModel( DefaultOrCustomModel( "models/dog.mdl" ) );
+#else
 	SetModel( "models/dog.mdl" );
+#endif
 
 	SetHullType( HULL_WIDE_HUMAN );
 	SetHullSizeNormal();
@@ -638,7 +642,11 @@ void CNPC_Dog::PullObject( bool bMantain )
 //-----------------------------------------------------------------------------
 void CNPC_Dog::Precache( void )
 {
+#ifdef MAPBASE
+	PrecacheModel( DefaultOrCustomModel( "models/dog.mdl" ) );
+#else
 	PrecacheModel( "models/dog.mdl" );
+#endif
 	
 	PrecacheScriptSound( "Weapon_PhysCannon.Launch" );
 

--- a/sp/src/game/server/hl2/npc_fastzombie.cpp
+++ b/sp/src/game/server/hl2/npc_fastzombie.cpp
@@ -396,7 +396,11 @@ static const char *s_pLegsModel = "models/gibs/fast_zombie_legs.mdl";
 //-----------------------------------------------------------------------------
 void CFastZombie::Precache( void )
 {
+#ifdef MAPBASE
+	PrecacheModel( DefaultOrCustomModel( "models/zombie/fast.mdl" ) );
+#else
 	PrecacheModel("models/zombie/fast.mdl");
+#endif
 #ifdef HL2_EPISODIC
 	PrecacheModel("models/zombie/Fast_torso.mdl");
 	PrecacheScriptSound( "NPC_FastZombie.CarEnter1" );
@@ -768,12 +772,20 @@ void CFastZombie::SetZombieModel( void )
 
 	if ( m_fIsTorso )
 	{
+#ifdef MAPBASE
+		SetModel( DefaultOrCustomModel( "models/zombie/fast_torso.mdl" ) );
+#else
 		SetModel( "models/zombie/fast_torso.mdl" );
+#endif
 		SetHullType(HULL_TINY);
 	}
 	else
 	{
+#ifdef MAPBASE
+		SetModel( DefaultOrCustomModel( "models/zombie/fast.mdl" ) );
+#else
 		SetModel( "models/zombie/fast.mdl" );
+#endif
 		SetHullType(HULL_HUMAN);
 	}
 

--- a/sp/src/game/server/hl2/npc_fisherman.cpp
+++ b/sp/src/game/server/hl2/npc_fisherman.cpp
@@ -133,7 +133,11 @@ END_DATADESC()
 //-----------------------------------------------------------------------------
 void CNPC_Fisherman::SelectModel()
 {
+#ifdef MAPBASE
+	SetModelName( AllocPooledString( DefaultOrCustomModel( FISHERMAN_MODEL ) ) );
+#else
 	SetModelName( AllocPooledString( FISHERMAN_MODEL ) );
+#endif
 }
 
 //-----------------------------------------------------------------------------

--- a/sp/src/game/server/hl2/npc_gman.cpp
+++ b/sp/src/game/server/hl2/npc_gman.cpp
@@ -97,7 +97,11 @@ void CNPC_GMan::Spawn()
 
 	BaseClass::Spawn();
 
+#ifdef MAPBASE
+	SetModel( DefaultOrCustomModel( "models/gman.mdl" ) );
+#else
 	SetModel( "models/gman.mdl" );
+#endif
 
 	SetHullType(HULL_HUMAN);
 	SetHullSizeNormal();
@@ -123,7 +127,11 @@ void CNPC_GMan::Spawn()
 //-----------------------------------------------------------------------------
 void CNPC_GMan::Precache()
 {
+#ifdef MAPBASE
+	PrecacheModel( DefaultOrCustomModel( "models/gman.mdl" ) );
+#else
 	PrecacheModel( "models/gman.mdl" );
+#endif
 	
 	BaseClass::Precache();
 }	

--- a/sp/src/game/server/hl2/npc_monk.cpp
+++ b/sp/src/game/server/hl2/npc_monk.cpp
@@ -299,7 +299,11 @@ Activity CNPC_Monk::NPC_TranslateActivity( Activity eNewActivity )
 //-----------------------------------------------------------------------------
 void CNPC_Monk::Precache()
 {
+#ifdef MAPBASE
+	PrecacheModel( DefaultOrCustomModel( "models/Monk.mdl" ) );
+#else
 	PrecacheModel( "models/Monk.mdl" );
+#endif
 	
 	PrecacheScriptSound( "NPC_Citizen.FootstepLeft" );
 	PrecacheScriptSound( "NPC_Citizen.FootstepRight" );
@@ -317,7 +321,11 @@ void CNPC_Monk::Spawn()
 
 	BaseClass::Spawn();
 
+#ifdef MAPBASE
+	SetModel( DefaultOrCustomModel( "models/Monk.mdl" ) );
+#else
 	SetModel( "models/Monk.mdl" );
+#endif
 
 	SetHullType(HULL_HUMAN);
 	SetHullSizeNormal();

--- a/sp/src/game/server/hl2/npc_mossman.cpp
+++ b/sp/src/game/server/hl2/npc_mossman.cpp
@@ -99,7 +99,11 @@ void CNPC_Mossman::Spawn()
 
 	BaseClass::Spawn();
 
+#ifdef MAPBASE
+	SetModel( DefaultOrCustomModel( "models/mossman.mdl" ) );
+#else
 	SetModel( "models/mossman.mdl" );
+#endif
 
 	SetHullType(HULL_HUMAN);
 	SetHullSizeNormal();
@@ -124,7 +128,11 @@ void CNPC_Mossman::Spawn()
 //-----------------------------------------------------------------------------
 void CNPC_Mossman::Precache()
 {
+#ifdef MAPBASE
+	PrecacheModel( DefaultOrCustomModel( "models/mossman.mdl" ) );
+#else
 	PrecacheModel( "models/mossman.mdl" );
+#endif
 	
 	BaseClass::Precache();
 }	

--- a/sp/src/game/server/hl2/npc_zombie.cpp
+++ b/sp/src/game/server/hl2/npc_zombie.cpp
@@ -250,7 +250,11 @@ void CZombie::Precache( void )
 {
 	BaseClass::Precache();
 
+#ifdef MAPBASE
+	PrecacheModel( DefaultOrCustomModel( "models/zombie/classic.mdl" ) );
+#else
 	PrecacheModel( "models/zombie/classic.mdl" );
+#endif
 	PrecacheModel( "models/zombie/classic_torso.mdl" );
 	PrecacheModel( "models/zombie/classic_legs.mdl" );
 
@@ -509,12 +513,20 @@ void CZombie::SetZombieModel( void )
 
 	if ( m_fIsTorso )
 	{
+#ifdef MAPBASE
+		SetModel( DefaultOrCustomModel( "models/zombie/classic_torso.mdl" ) );
+#else
 		SetModel( "models/zombie/classic_torso.mdl" );
+#endif
 		SetHullType( HULL_TINY );
 	}
 	else
 	{
+#ifdef MAPBASE
+		SetModel( DefaultOrCustomModel( "models/zombie/classic.mdl" ) );
+#else
 		SetModel( "models/zombie/classic.mdl" );
+#endif
 		SetHullType( HULL_HUMAN );
 	}
 

--- a/sp/src/game/server/hl2/npc_zombine.cpp
+++ b/sp/src/game/server/hl2/npc_zombine.cpp
@@ -249,7 +249,11 @@ void CNPC_Zombine::Precache( void )
 {
 	BaseClass::Precache();
 
+#ifdef MAPBASE
+	PrecacheModel( DefaultOrCustomModel( "models/zombie/zombie_soldier.mdl" ) );
+#else
 	PrecacheModel( "models/zombie/zombie_soldier.mdl" );
+#endif
 
 	PrecacheScriptSound( "Zombie.FootstepRight" );
 	PrecacheScriptSound( "Zombie.FootstepLeft" );
@@ -270,7 +274,11 @@ void CNPC_Zombine::Precache( void )
 
 void CNPC_Zombine::SetZombieModel( void )
 {
+#ifdef MAPBASE
+	SetModel( DefaultOrCustomModel( "models/zombie/zombie_soldier.mdl" ) );
+#else
 	SetModel( "models/zombie/zombie_soldier.mdl" );
+#endif
 	SetHullType( HULL_HUMAN );
 
 	SetBodygroup( ZOMBIE_BODYGROUP_HEADCRAB, !m_fIsHeadless );

--- a/sp/src/game/server/lab/npc_houndeye.cpp
+++ b/sp/src/game/server/lab/npc_houndeye.cpp
@@ -191,7 +191,11 @@ END_DATADESC()
 
 void CHoundeye::Precache(void)
 {
+#ifdef MAPBASE
+	PrecacheModel( DefaultOrCustomModel( "models/houndeye.mdl" ) );
+#else
 	PrecacheModel("models/houndeye.mdl");
+#endif
 	PrecacheScriptSound("NPC_Houndeye.Idle");
 	PrecacheScriptSound("NPC_Houndeye.Sonic");
 	PrecacheScriptSound("NPC_Houndeye.Alert");
@@ -216,7 +220,11 @@ void CHoundeye::Spawn(void)
 {
 	Precache();
 
+#ifdef MAPBASE
+	SetModel( DefaultOrCustomModel( "models/houndeye.mdl" ) );
+#else
 	SetModel("models/houndeye.mdl");
+#endif
 	BaseClass::Spawn();
 	SetHullType(HULL_MEDIUM); //TODO: Look into a custom 48x48x48 hull in the future
 	SetHullSizeNormal();

--- a/sp/src/game/server/lab/npc_lost_soul.cpp
+++ b/sp/src/game/server/lab/npc_lost_soul.cpp
@@ -135,7 +135,11 @@ void CNPC_LostSoul::InitCustomSchedules(void)
 //-----------------------------------------------------------------------------
 void CNPC_LostSoul::Precache( void )
 {
-	PrecacheModel( "models/skeleton/skeleton_torso3.mdl" ); // Replace this with setting from Hammer
+#ifdef MAPBASE
+	PrecacheModel( DefaultOrCustomModel( "models/skeleton/skeleton_torso3.mdl" ) );
+#else
+	PrecacheModel( "models/skeleton/skeleton_torso3.mdl" );
+#endif
 
 	PrecacheScriptSound("NPC_LostSoul.Die");
 	PrecacheScriptSound("NPC_LostSoul.Burn");
@@ -160,7 +164,11 @@ void CNPC_LostSoul::Spawn( void )
 
 	Precache();
 
+#ifdef MAPBASE
+	SetModel( DefaultOrCustomModel( "models/skeleton/skeleton_torso3.mdl" ) );
+#else
 	SetModel("models/skeleton/skeleton_torso3.mdl");
+#endif
 	SetHullType(HULL_TINY_CENTERED); // There was an error being thrown about collision model being smaller than nav hull - need to look into
 	SetHullSizeNormal();
 


### PR DESCRIPTION
This PR expands custom model capacities on most HL2 ( and Map Labs ) NPCs, by adding support for native custom model support.
Allowing to define custom models before the NPC spawns, evades issues found later when applied post-spawn ( ranging from issues with phymodels or AI schedules not correctly running, to even some hitboxes not updating or even mod crashes ), especially after save-reloading a game.

Some NPCs like the Rollermine, the Antlion Grub or the Crow haven't been updated yet, as they require extra parameters to define the additional models they use ( like a squashed or extended variant ), and kinda would go further than what this commit is aiming to.

Note that this wouldn't solve the issue where a model of a substantial different size is applied to a NPC with a hull that differs in size, leading to attacks "going through" most of the model.
Cvoxalury brought my attention to the entity `generic_actor`, which possess options to select different hull sizes without having to hardcoding them on the NPC. Such an option would solve this issue and add extra customization, but it needs to be experimented with first.

[I have included on the following link](https://www.mediafire.com/file/7bx3ky6ib8qj31l/custom_model_test_map.7z/file
) a test map ( both VMF and BSP ), showcasing those, as well as updated FGDs to address the change.
These FGDs also solves a minor bug related with the `npc_fisherman` using the Barney model in Hammer, as well as removing "default model paths" on the custom model fields ( Not only it's redundant as the code will load the default models if no custom model path is passed, it will also solve potential future issues on mods, where they might change the path of a model, but the map would still use the old one ).

Ignoring the Map Labs NPCs, this PR could be rolled into MapBase as well.

---

#### Does this PR close any issues?
No.

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [X] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [ ] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
